### PR TITLE
fix: use system-features endpoint to obtain version

### DIFF
--- a/PSDify.psd1
+++ b/PSDify.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule           = 'PSDify.psm1'
-    ModuleVersion        = '0.6.0'
+    ModuleVersion        = '0.6.1'
     CompatiblePSEditions = @('Core', 'Desktop')
     GUID                 = 'b791c4c0-ed46-4561-8713-5d4242e6bac7'
     Author               = 'kurokobo'

--- a/Public/Get-DifyVersion.ps1
+++ b/Public/Get-DifyVersion.ps1
@@ -24,7 +24,7 @@ function Get-DifyVersion {
     $Body = $Response.Content | ConvertFrom-Json
     $PluginSupport = $null -ne $Body.enable_marketplace
 
-    [PSCustomObject]@{
+    return [PSCustomObject]@{
         "Server"        = $Server
         "Version"       = $Version
         "PluginSupport" = $PluginSupport

--- a/Tests/Invoke-PSDifyPester.ps1
+++ b/Tests/Invoke-PSDifyPester.ps1
@@ -24,7 +24,7 @@ $Environments = @(
     @{
         Id       = "community-release"
         Mode     = "community"
-        Version  = "1.8.1"
+        Version  = "1.9.0"
         Override = "compose_release.yaml"
         Env      = "env_release.env"
     },


### PR DESCRIPTION
Dify 1.9.0 requires the `current_version` field for requests to the `version` endpoint, so the previous method to get the version no longer works.

I'll update it to refer to the `x-version` value in the response header, just like the Web UI does.

This is compatible with 1.8.1 or older.